### PR TITLE
fix: Should filter not nil instead of truthy value

### DIFF
--- a/lib/coercions/struct.ex
+++ b/lib/coercions/struct.ex
@@ -20,7 +20,7 @@ defmodule ExchemaCoercion.Coercions.Struct do
   defp fuzzy_get(map, key) do
     [& &1, &to_string/1]
     |> Enum.map(&Map.get(map, &1.(key)))
-    |> Enum.filter(& &1)
+    |> Enum.filter(& not is_nil(&1))
     |> List.first()
   end
 end

--- a/test/exchema_coercion_test.exs
+++ b/test/exchema_coercion_test.exs
@@ -11,6 +11,7 @@ defmodule ExchemaCoercionTest do
   subtype(CustomCoercion, :any, [])
 
   structure(Struct, foo: T.Integer)
+  structure(StructWithBoolean, foo: T.Boolean)
 
   structure(Nested, child: {T.Optional, Nested})
 
@@ -65,6 +66,7 @@ defmodule ExchemaCoercionTest do
     assert coerce("true", T.Boolean)
     refute coerce("false", T.Boolean)
     assert "nothing" = coerce("nothing", T.Boolean)
+    assert %StructWithBoolean{foo: false} = coerce(%{"foo" => false}, StructWithBoolean)
   end
 
   test "coercing strings" do


### PR DESCRIPTION
This PR fixes a bug that it didn't allowed me to coerce a boolean to a boolean nested in a struct.